### PR TITLE
Add Google Apps Script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ async myFn(){
 myFn();
 ```
 
+## Usando no Google Sheets
+
+Também é possível consultar o rastreamento diretamente em uma planilha do
+Google. O diretório `appscript` contém um exemplo de script (`Code.gs`) pronto
+para ser adicionado ao seu projeto do **Google Apps Script**.
+
+1. Abra o menu `Extensões` > `Apps Script` em sua planilha.
+2. Crie um novo arquivo `Code.gs` e copie o conteúdo de `appscript/Code.gs`.
+3. Salve o projeto e utilize a função `TRACK_CORREIOS` nas células, por exemplo:
+
+```gs
+=TRACK_CORREIOS("XX000000000BR")
+```
+
+A função retorna um array de objetos contendo as informações de rastreio, de
+forma semelhante ao uso da biblioteca em Node.js.
+
+
 ### Utilizando o ES6
 
 ```js

--- a/appscript/Code.gs
+++ b/appscript/Code.gs
@@ -1,0 +1,103 @@
+/**
+ * Example Google Apps Script to fetch Correios tracking information using the
+ * MelhorEnvio API. This script mimics part of the "rastreio-correios"
+ * functionality and can be used inside Google Sheets.
+ *
+ * Usage inside a cell:
+ *   =TRACK_CORREIOS("XX000000000BR")
+ *   or =TRACK_CORREIOS(A1:A5)
+ */
+
+/**
+ * Validate the tracking code format.
+ */
+function CODE_VALIDATOR(code) {
+  return code && code.length === 13 && /^[A-Z]{2}\d{9}[A-Z]{2}$/.test(code);
+}
+
+function getHora(date) {
+  if (date.length === 24) {
+    return date.slice(11, -8);
+  }
+  return date.replace(/(.)+ /, '').slice(0, -3);
+}
+
+function getDate(date) {
+  if (date.length === 24) {
+    return date.slice(0, -14);
+  }
+  return date.replace(/ (.)+/, '');
+}
+
+/**
+ * Convert a MelhorEnvio tracking event to a simpler object.
+ */
+function formatEvents(events) {
+  return events.map(function(item) {
+    var ev = {
+      status: item.events,
+      data: getDate(item.date),
+      hora: getHora(item.date),
+      origem: item.local + ' - ' + (item.city || '') + ' / ' + (item.uf || ''),
+      local: item.local + ' - ' + (item.city || '') + ' / ' + (item.uf || '')
+    };
+    if (item.destination_local) {
+      ev.destino = item.destination_local + ' - ' +
+        (item.destination_city || '') + ' / ' + (item.destination_uf || '');
+    }
+    if (item.comment) ev.comentario = item.comment;
+    return ev;
+  });
+}
+
+/**
+ * Fetch tracking data for a single code using MelhorEnvio API.
+ */
+function fetchMelhorEnvio(code) {
+  var url = 'https://api.melhorrastreio.com.br/api/v1/trackings/' + code;
+  var response = UrlFetchApp.fetch(url, { 'muteHttpExceptions': true });
+  if (response.getResponseCode() !== 200) throw new Error('Erro ao consultar API');
+  var data = JSON.parse(response.getContentText());
+  if (!data.success) throw new Error('Rastreamento não encontrado');
+  return data;
+}
+
+/**
+ * Main function callable from a Spreadsheet.
+ * Returns an array of tracking results.
+ */
+function TRACK_CORREIOS(codes) {
+  if (!codes) throw new Error('Códigos de rastreio não foram informados');
+  if (!Array.isArray(codes)) codes = [codes];
+
+  var results = [];
+  for (var i = 0; i < codes.length; i++) {
+    var code = codes[i];
+    var start = new Date().getTime();
+    var item = { sucesso: false, rastreio: code, responseTime: 0 };
+
+    if (!CODE_VALIDATOR(code)) {
+      item.mensagem = 'Código de rastreio inválido';
+      results.push(item);
+      continue;
+    }
+
+    try {
+      var data = fetchMelhorEnvio(code);
+      var eventos = formatEvents(data.data.events);
+      var entregue = eventos.some(function(ev) {
+        return ev.status.toLowerCase().indexOf('entregue') !== -1;
+      });
+      item.sucesso = true;
+      item.eventos = eventos;
+      item.entregue = entregue;
+    } catch (e) {
+      item.mensagem = e.message;
+    }
+
+    item.responseTime = new Date().getTime() - start;
+    results.push(item);
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- add example `Code.gs` script for Google Apps Script
- document how to use the script from Google Sheets

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails to resolve modules)*


------
https://chatgpt.com/codex/tasks/task_e_68596ff30f0c8329b73e1edff60fb188